### PR TITLE
move function to py from vue that arrange datetime

### DIFF
--- a/server/task/serializers.py
+++ b/server/task/serializers.py
@@ -1,6 +1,11 @@
 from django.contrib.auth.models import User
 from .models import Custom, Todo
 from rest_framework import serializers
+import json
+from pytz import timezone as tz
+from django.utils import timezone
+import datetime
+from django.core.serializers.json import DjangoJSONEncoder
 
 
 class UserSerializer(serializers.ModelSerializer):
@@ -12,18 +17,21 @@ class UserSerializer(serializers.ModelSerializer):
 
 class TodoSerializer(serializers.ModelSerializer):
     """A serializer for the Todo model"""
-    # d_date = serializers.SerializerMethodField()
-    # d_time = serializers.SerializerMethodField()
+    d_date = serializers.SerializerMethodField()
+    d_time = serializers.SerializerMethodField()
+    deadline_time = serializers.DateTimeField(format="%Y-%m-%d %H:%M:%S %Z")
 
     class Meta:
         model = Todo
-        fields = ('id', 'author', 'title', 'start_time', 'end_time', 'deadline_time')
+        fields = ('id', 'author', 'title', 'start_time', 'end_time', 'deadline_time', 'd_date', 'd_time')
 
-    # def get_d_date(self, instance):
-    #     pass
-    #
-    # def get_d_time(self, instance):
-    #     pass
+
+    def get_d_date(self, obj):
+        return obj.deadline_time.astimezone(tz('Asia/Tokyo')).strftime("%Y-%m-%d")
+
+    def get_d_time(self, obj):
+        return obj.deadline_time.astimezone(tz('Asia/Tokyo')).strftime("%H:%M:%S")
+
 
 
 class CustomSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
実装の際はserializermethodFieldでフィールドの値を定義する関数をバインドし、関数内ではdeadline_timeカラムから値を取得し、それを日、時間にフォーマットしリターンすることで解決。
タイムゾーンの設定がデフォルトでUTCになるになってしまうところで若干詰まった。値を取得後、タイムゾーンを変更することで事なきを得たが国際展開したら今のコードでは駄目になりそう()